### PR TITLE
Hide NodeIterator.

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -216,6 +216,18 @@ macro_rules! table_row_access {
     };
 }
 
+macro_rules! iterator_for_nodeiterator {
+    ($ty: ty) => {
+        impl Iterator for $ty {
+            type Item = crate::tsk_id_t;
+            fn next(&mut self) -> Option<Self::Item> {
+                self.next_node();
+                self.current_node()
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 mod test {
     use crate::error::TskitError;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -44,7 +44,7 @@ impl<T: Copy> WrappedTskArray<T> {
     ///
     /// This function returns the raw C pointer,
     /// and is thus unsafe.
-    pub unsafe fn as_ptr(&self) -> *const T {
+    pub fn as_ptr(&self) -> *const T {
         self.array
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ pub use node_table::{NodeTable, NodeTableRow};
 pub use population_table::{PopulationTable, PopulationTableRow};
 pub use site_table::{SiteTable, SiteTableRow};
 pub use table_collection::TableCollection;
-pub use traits::NodeIterator;
 pub use traits::NodeListGenerator;
 pub use traits::TableAccess;
 pub use traits::TskitTypeAccess;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -197,18 +197,3 @@ pub trait NodeListGenerator: TableAccess {
         self.nodes().create_node_id_vector(f)
     }
 }
-
-/// Trait defining iteration over nodes.
-pub trait NodeIterator {
-    fn next_node(&mut self);
-    fn current_node(&mut self) -> Option<tsk_id_t>;
-}
-
-impl Iterator for dyn NodeIterator {
-    type Item = tsk_id_t;
-
-    fn next(&mut self) -> Option<tsk_id_t> {
-        self.next_node();
-        self.current_node()
-    }
-}


### PR DESCRIPTION
This PR completes type erasure for NodeIterator.  The NoderIterator trait implementations themselves also no longer use the low-level array wrappers (see #99).