### PR TITLE
Add convenience macro to use all public traits.

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -1,5 +1,18 @@
 #![macro_use]
 
+/// Convenience macro issuing `use` for all public traits.
+#[macro_export]
+macro_rules! enable_tskit_traits {
+    () => {
+        use $crate::metadata::MetadataRoundtrip;
+        #[cfg(feature = "provenance")]
+        use $crate::provenance::Provenance;
+        use $crate::NodeListGenerator;
+        use $crate::TableAccess;
+        use $crate::TskitTypeAccess;
+    };
+}
+
 #[doc(hidden)]
 macro_rules! handle_tsk_return_value {
     ($code: expr) => {{


### PR DESCRIPTION
Pros:

* Streamlines things for people new to rust.

Cons:

* Brings stuff into scope you may not use
* Requires maintenance when new traits are added.