### PR TITLE
streamline API for creating table row objects

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -156,11 +156,8 @@ macro_rules! decode_metadata_row {
 }
 
 macro_rules! table_row_decode_metadata {
-    ($decode_metadata: ident, $table: ident, $pos: ident) => {
-        match $decode_metadata {
-            true => metadata_to_vector!($table, $pos).unwrap().map(|x| x),
-            false => None,
-        }
+    ($table: ident, $pos: ident) => {
+        metadata_to_vector!($table, $pos).unwrap().map(|x| x)
     };
 }
 
@@ -191,11 +188,11 @@ macro_rules! err_if_not_tracking_samples {
 // Here, we convert the None type to an Error,
 // as it applies $row is out of range.
 macro_rules! table_row_access {
-    ($row: expr, $decode_metadata: expr, $table: expr, $row_fn: ident) => {
+    ($row: expr, $table: expr, $row_fn: ident) => {
         if $row < 0 {
             Err(TskitError::IndexError)
         } else {
-            match $row_fn($table, $row, $decode_metadata) {
+            match $row_fn($table, $row) {
                 Some(x) => Ok(x),
                 None => Err(TskitError::IndexError),
             }

--- a/src/edge_table.rs
+++ b/src/edge_table.rs
@@ -23,11 +23,7 @@ impl PartialEq for EdgeTableRow {
     }
 }
 
-fn make_edge_table_row(
-    table: &EdgeTable,
-    pos: tsk_id_t,
-    decode_metadata: bool,
-) -> Option<EdgeTableRow> {
+fn make_edge_table_row(table: &EdgeTable, pos: tsk_id_t) -> Option<EdgeTableRow> {
     if pos < table.num_rows() as tsk_id_t {
         let rv = EdgeTableRow {
             id: pos,
@@ -35,7 +31,7 @@ fn make_edge_table_row(
             right: table.right(pos).unwrap(),
             parent: table.parent(pos).unwrap(),
             child: table.child(pos).unwrap(),
-            metadata: table_row_decode_metadata!(decode_metadata, table, pos),
+            metadata: table_row_decode_metadata!(table, pos),
         };
         Some(rv)
     } else {
@@ -50,7 +46,7 @@ impl<'a> Iterator for EdgeTableRefIterator<'a> {
     type Item = EdgeTableRow;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let rv = make_edge_table_row(self.table, self.pos, self.decode_metadata);
+        let rv = make_edge_table_row(self.table, self.pos);
         self.pos += 1;
         rv
     }
@@ -60,7 +56,7 @@ impl<'a> Iterator for EdgeTableIterator<'a> {
     type Item = EdgeTableRow;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let rv = make_edge_table_row(&self.table, self.pos, self.decode_metadata);
+        let rv = make_edge_table_row(&self.table, self.pos);
         self.pos += 1;
         rv
     }
@@ -136,15 +132,8 @@ impl<'a> EdgeTable<'a> {
     /// Return an iterator over rows of the table.
     /// The value of the iterator is [`EdgeTableRow`].
     ///
-    /// # Parameters
-    ///
-    /// * `decode_metadata`: if `true`, then a *copy* of row metadata
-    ///    will be provided in [`EdgeTableRow::metadata`].
-    ///    The meta data are *not* decoded.
-    ///    Rows with no metadata will contain the value `None`.
-    ///
-    pub fn iter(&self, decode_metadata: bool) -> EdgeTableRefIterator {
-        crate::table_iterator::make_table_iterator::<&EdgeTable<'a>>(&self, decode_metadata)
+    pub fn iter(&self) -> EdgeTableRefIterator {
+        crate::table_iterator::make_table_iterator::<&EdgeTable<'a>>(&self)
     }
 
     /// Return row `r` of the table.
@@ -152,15 +141,11 @@ impl<'a> EdgeTable<'a> {
     /// # Parameters
     ///
     /// * `r`: the row id.
-    /// * `decode_metadata`: if `true`, then a *copy* of row metadata
-    ///    will be provided in [`EdgeTableRow::metadata`].
-    ///    The meta data are *not* decoded.
-    ///    Rows with no metadata will contain the value `None`.
     ///
     /// # Errors
     ///
     /// [`TskitError::IndexError`] if `r` is out of range.
-    pub fn row(&self, r: tsk_id_t, decode_metadata: bool) -> Result<EdgeTableRow, TskitError> {
-        table_row_access!(r, decode_metadata, self, make_edge_table_row)
+    pub fn row(&self, r: tsk_id_t) -> Result<EdgeTableRow, TskitError> {
+        table_row_access!(r, self, make_edge_table_row)
     }
 }

--- a/src/individual_table.rs
+++ b/src/individual_table.rs
@@ -47,18 +47,14 @@ pub struct IndividualTable<'a> {
     table_: &'a ll_bindings::tsk_individual_table_t,
 }
 
-fn make_individual_table_row(
-    table: &IndividualTable,
-    pos: tsk_id_t,
-    decode_metadata: bool,
-) -> Option<IndividualTableRow> {
+fn make_individual_table_row(table: &IndividualTable, pos: tsk_id_t) -> Option<IndividualTableRow> {
     if pos < table.num_rows() as tsk_id_t {
         let rv = IndividualTableRow {
             id: pos,
             flags: table.flags(pos).unwrap(),
             location: table.location(pos).unwrap(),
             parents: table.parents(pos).unwrap(),
-            metadata: table_row_decode_metadata!(decode_metadata, table, pos),
+            metadata: table_row_decode_metadata!(table, pos),
         };
         Some(rv)
     } else {
@@ -139,15 +135,8 @@ impl<'a> IndividualTable<'a> {
     /// Return an iterator over rows of the table.
     /// The value of the iterator is [`IndividualTableRow`].
     ///
-    /// # Parameters
-    ///
-    /// * `decode_metadata`: if `true`, then a *copy* of row metadata
-    ///    will be provided in [`IndividualTableRow::metadata`].
-    ///    The meta data are *not* decoded.
-    ///    Rows with no metadata will contain the value `None`.
-    ///
-    pub fn iter(&self, decode_metadata: bool) -> IndividualTableRefIterator {
-        crate::table_iterator::make_table_iterator::<&IndividualTable<'a>>(&self, decode_metadata)
+    pub fn iter(&self) -> IndividualTableRefIterator {
+        crate::table_iterator::make_table_iterator::<&IndividualTable<'a>>(&self)
     }
 
     /// Return row `r` of the table.
@@ -155,19 +144,11 @@ impl<'a> IndividualTable<'a> {
     /// # Parameters
     ///
     /// * `r`: the row id.
-    /// * `decode_metadata`: if `true`, then a *copy* of row metadata
-    ///    will be provided in [`IndividualTableRow::metadata`].
-    ///    The meta data are *not* decoded.
-    ///    Rows with no metadata will contain the value `None`.
     ///
     /// # Errors
     ///
     /// [`TskitError::IndexError`] if `r` is out of range.
-    pub fn row(
-        &self,
-        r: tsk_id_t,
-        decode_metadata: bool,
-    ) -> Result<IndividualTableRow, TskitError> {
-        table_row_access!(r, decode_metadata, self, make_individual_table_row)
+    pub fn row(&self, r: tsk_id_t) -> Result<IndividualTableRow, TskitError> {
+        table_row_access!(r, self, make_individual_table_row)
     }
 }

--- a/src/population_table.rs
+++ b/src/population_table.rs
@@ -16,15 +16,11 @@ impl PartialEq for PopulationTableRow {
     }
 }
 
-fn make_population_table_row(
-    table: &PopulationTable,
-    pos: tsk_id_t,
-    decode_metadata: bool,
-) -> Option<PopulationTableRow> {
+fn make_population_table_row(table: &PopulationTable, pos: tsk_id_t) -> Option<PopulationTableRow> {
     if pos < table.num_rows() as tsk_id_t {
         let rv = PopulationTableRow {
             id: pos,
-            metadata: table_row_decode_metadata!(decode_metadata, table, pos),
+            metadata: table_row_decode_metadata!(table, pos),
         };
         Some(rv)
     } else {
@@ -40,7 +36,7 @@ impl<'a> Iterator for PopulationTableRefIterator<'a> {
     type Item = PopulationTableRow;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let rv = make_population_table_row(&self.table, self.pos, self.decode_metadata);
+        let rv = make_population_table_row(&self.table, self.pos);
         self.pos += 1;
         rv
     }
@@ -50,7 +46,7 @@ impl<'a> Iterator for PopulationTableIterator<'a> {
     type Item = PopulationTableRow;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let rv = make_population_table_row(&self.table, self.pos, self.decode_metadata);
+        let rv = make_population_table_row(&self.table, self.pos);
         self.pos += 1;
         rv
     }
@@ -85,16 +81,8 @@ impl<'a> PopulationTable<'a> {
 
     /// Return an iterator over rows of the table.
     /// The value of the iterator is [`PopulationTableRow`].
-    ///
-    /// # Parameters
-    ///
-    /// * `decode_metadata`: if `true`, then a *copy* of row metadata
-    ///    will be provided in [`PopulationTableRow::metadata`].
-    ///    The meta data are *not* decoded.
-    ///    Rows with no metadata will contain the value `None`.
-    ///
-    pub fn iter(&self, decode_metadata: bool) -> PopulationTableRefIterator {
-        crate::table_iterator::make_table_iterator::<&PopulationTable<'a>>(&self, decode_metadata)
+    pub fn iter(&self) -> PopulationTableRefIterator {
+        crate::table_iterator::make_table_iterator::<&PopulationTable<'a>>(&self)
     }
 
     /// Return row `r` of the table.
@@ -102,19 +90,11 @@ impl<'a> PopulationTable<'a> {
     /// # Parameters
     ///
     /// * `r`: the row id.
-    /// * `decode_metadata`: if `true`, then a *copy* of row metadata
-    ///    will be provided in [`PopulationTableRow::metadata`].
-    ///    The meta data are *not* decoded.
-    ///    Rows with no metadata will contain the value `None`.
     ///
     /// # Errors
     ///
     /// [`TskitError::IndexError`] if `r` is out of range.
-    pub fn row(
-        &self,
-        r: tsk_id_t,
-        decode_metadata: bool,
-    ) -> Result<PopulationTableRow, TskitError> {
-        table_row_access!(r, decode_metadata, self, make_population_table_row)
+    pub fn row(&self, r: tsk_id_t) -> Result<PopulationTableRow, TskitError> {
+        table_row_access!(r, self, make_population_table_row)
     }
 }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -106,7 +106,7 @@ pub trait Provenance: crate::TableAccess {
     /// Return an iterator over the rows of the [`ProvenanceTable`].
     /// See [`ProvenanceTable::iter`] for details.
     fn provenances_iter(&self) -> ProvenanceTableIterator {
-        crate::table_iterator::make_table_iterator::<ProvenanceTable>(self.provenances(), false)
+        crate::table_iterator::make_table_iterator::<ProvenanceTable>(self.provenances())
     }
 }
 
@@ -263,6 +263,6 @@ impl<'a> ProvenanceTable<'a> {
     /// Return an iterator over rows of the table.
     /// The value of the iterator is [`ProvenanceTableRow`].
     pub fn iter(&self) -> ProvenanceTableRefIterator {
-        crate::table_iterator::make_table_iterator::<&ProvenanceTable<'a>>(&self, false)
+        crate::table_iterator::make_table_iterator::<&ProvenanceTable<'a>>(&self)
     }
 }

--- a/src/site_table.rs
+++ b/src/site_table.rs
@@ -20,17 +20,13 @@ impl PartialEq for SiteTableRow {
     }
 }
 
-fn make_site_table_row(
-    table: &SiteTable,
-    pos: tsk_id_t,
-    decode_metadata: bool,
-) -> Option<SiteTableRow> {
+fn make_site_table_row(table: &SiteTable, pos: tsk_id_t) -> Option<SiteTableRow> {
     if pos < table.num_rows() as tsk_id_t {
         let rv = SiteTableRow {
             id: pos,
             position: table.position(pos).unwrap(),
             ancestral_state: table.ancestral_state(pos).unwrap(),
-            metadata: table_row_decode_metadata!(decode_metadata, table, pos),
+            metadata: table_row_decode_metadata!(table, pos),
         };
         Some(rv)
     } else {
@@ -45,7 +41,7 @@ impl<'a> Iterator for SiteTableRefIterator<'a> {
     type Item = SiteTableRow;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let rv = make_site_table_row(&self.table, self.pos, self.decode_metadata);
+        let rv = make_site_table_row(&self.table, self.pos);
         self.pos += 1;
         rv
     }
@@ -55,7 +51,7 @@ impl<'a> Iterator for SiteTableIterator<'a> {
     type Item = SiteTableRow;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let rv = make_site_table_row(&self.table, self.pos, self.decode_metadata);
+        let rv = make_site_table_row(&self.table, self.pos);
         self.pos += 1;
         rv
     }
@@ -120,16 +116,8 @@ impl<'a> SiteTable<'a> {
 
     /// Return an iterator over rows of the table.
     /// The value of the iterator is [`SiteTableRow`].
-    ///
-    /// # Parameters
-    ///
-    /// * `decode_metadata`: if `true`, then a *copy* of row metadata
-    ///    will be provided in [`SiteTableRow::metadata`].
-    ///    The meta data are *not* decoded.
-    ///    Rows with no metadata will contain the value `None`.
-    ///
-    pub fn iter(&self, decode_metadata: bool) -> SiteTableRefIterator {
-        crate::table_iterator::make_table_iterator::<&SiteTable<'a>>(&self, decode_metadata)
+    pub fn iter(&self) -> SiteTableRefIterator {
+        crate::table_iterator::make_table_iterator::<&SiteTable<'a>>(&self)
     }
 
     /// Return row `r` of the table.
@@ -137,15 +125,11 @@ impl<'a> SiteTable<'a> {
     /// # Parameters
     ///
     /// * `r`: the row id.
-    /// * `decode_metadata`: if `true`, then a *copy* of row metadata
-    ///    will be provided in [`SiteTableRow::metadata`].
-    ///    The meta data are *not* decoded.
-    ///    Rows with no metadata will contain the value `None`.
     ///
     /// # Errors
     ///
     /// [`TskitError::IndexError`] if `r` is out of range.
-    pub fn row(&self, r: tsk_id_t, decode_metadata: bool) -> Result<SiteTableRow, TskitError> {
-        table_row_access!(r, decode_metadata, self, make_site_table_row)
+    pub fn row(&self, r: tsk_id_t) -> Result<SiteTableRow, TskitError> {
+        table_row_access!(r, self, make_site_table_row)
     }
 }

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -95,7 +95,7 @@ use ll_bindings::tsk_table_collection_free;
 /// // Iterate over each row in the table.
 /// // The "true" means to include (a copy of) the
 /// // encoded metadata, if any exist.
-/// for row in tables.mutations().iter(true) {
+/// for row in tables.mutations().iter() {
 ///     // Decode the metadata if any exists.
 ///     if !row.metadata.is_none() {
 ///         let md = F::decode(&row.metadata.unwrap()).unwrap();
@@ -709,7 +709,7 @@ mod test {
             *t = -33.0;
         }
 
-        for i in tables.nodes_iter(true) {
+        for i in tables.nodes_iter() {
             assert_eq!(i.flags, 11);
             assert_eq!(i.time as i64, -33);
         }
@@ -718,7 +718,7 @@ mod test {
     #[test]
     fn test_node_iteration() {
         let tables = make_small_table_collection();
-        for (i, row) in tables.nodes().iter(true).enumerate() {
+        for (i, row) in tables.nodes().iter().enumerate() {
             assert!(close_enough(
                 tables.nodes().time(i as tsk_id_t).unwrap(),
                 row.time
@@ -735,7 +735,7 @@ mod test {
             assert!(row.metadata.is_none());
         }
 
-        for row in tables.nodes_iter(true) {
+        for row in tables.nodes_iter() {
             assert!(close_enough(tables.nodes().time(row.id).unwrap(), row.time));
             assert_eq!(tables.nodes().flags(row.id).unwrap(), row.flags);
             assert_eq!(tables.nodes().population(row.id).unwrap(), row.population);
@@ -747,7 +747,7 @@ mod test {
     #[test]
     fn test_edge_iteration() {
         let tables = make_small_table_collection();
-        for (i, row) in tables.edges().iter(true).enumerate() {
+        for (i, row) in tables.edges().iter().enumerate() {
             assert!(close_enough(
                 tables.edges().left(i as tsk_id_t).unwrap(),
                 row.left
@@ -760,7 +760,7 @@ mod test {
             assert_eq!(tables.edges().child(i as tsk_id_t).unwrap(), row.child);
             assert!(row.metadata.is_none());
         }
-        for row in tables.edges_iter(true) {
+        for row in tables.edges_iter() {
             assert!(close_enough(tables.edges().left(row.id).unwrap(), row.left));
             assert!(close_enough(
                 tables.edges().right(row.id).unwrap(),
@@ -827,7 +827,7 @@ mod test {
 
         // NOTE: this is a useful test as not all rows have ancestral_state
         let mut no_anc_state = 0;
-        for (i, row) in sites.iter(true).enumerate() {
+        for (i, row) in sites.iter().enumerate() {
             assert!(close_enough(
                 sites.position(i as tsk_id_t).unwrap(),
                 row.position
@@ -844,7 +844,7 @@ mod test {
         }
         assert_eq!(no_anc_state, 1);
         no_anc_state = 0;
-        for row in tables.sites_iter(true) {
+        for row in tables.sites_iter() {
             assert!(close_enough(sites.position(row.id).unwrap(), row.position));
             if row.ancestral_state.is_some() {
                 if row.id == 0 {
@@ -898,7 +898,7 @@ mod test {
         );
 
         let mut nmuts = 0;
-        for (i, row) in tables.mutations().iter(true).enumerate() {
+        for (i, row) in tables.mutations().iter().enumerate() {
             assert_eq!(row.site, tables.mutations().site(i as tsk_id_t).unwrap());
             assert_eq!(row.node, tables.mutations().node(i as tsk_id_t).unwrap());
             assert_eq!(
@@ -916,7 +916,7 @@ mod test {
         assert_eq!(nmuts, 3);
 
         nmuts = 0;
-        for row in tables.mutations_iter(true) {
+        for row in tables.mutations_iter() {
             assert_eq!(row.site, tables.mutations().site(row.id).unwrap());
             assert_eq!(row.node, tables.mutations().node(row.id).unwrap());
             assert_eq!(row.parent, tables.mutations().parent(row.id).unwrap());
@@ -929,12 +929,12 @@ mod test {
         }
         assert_eq!(nmuts, tables.mutations().num_rows());
         assert_eq!(nmuts, 3);
-        for row in tables.mutations().iter(false) {
+        for row in tables.mutations().iter() {
             assert!(row.metadata.is_none());
         }
 
         nmuts = 0;
-        for _ in tables.mutations().iter(true).skip(1) {
+        for _ in tables.mutations().iter().skip(1) {
             nmuts += 1;
         }
         assert_eq!(nmuts, tables.mutations().num_rows() - 1);
@@ -982,7 +982,7 @@ mod test {
         assert_eq!(md.x, -3);
         assert_eq!(md.y, 666);
 
-        for row in tables.mutations().iter(true) {
+        for row in tables.mutations().iter() {
             assert!(!row.metadata.is_none());
             let md = F::decode(&row.metadata.unwrap()).unwrap();
             assert_eq!(md.x, -3);
@@ -1092,12 +1092,12 @@ mod test {
     #[test]
     fn test_edge_table_row_equality() {
         let tables = make_small_table_collection();
-        for (i, row) in tables.edges_iter(true).enumerate() {
+        for (i, row) in tables.edges_iter().enumerate() {
             assert!(row.id == i as tsk_id_t);
-            assert!(row == tables.edges().row(i as tsk_id_t, true).unwrap());
-            assert!(!(row != tables.edges().row(i as tsk_id_t, true).unwrap()));
+            assert!(row == tables.edges().row(i as tsk_id_t).unwrap());
+            assert!(!(row != tables.edges().row(i as tsk_id_t).unwrap()));
             if i > 0 {
-                assert!(row != tables.edges().row(i as tsk_id_t - 1, true).unwrap());
+                assert!(row != tables.edges().row(i as tsk_id_t - 1).unwrap());
             }
         }
     }
@@ -1105,13 +1105,13 @@ mod test {
     #[test]
     fn test_node_table_row_equality() {
         let tables = make_small_table_collection();
-        for (i, row) in tables.nodes_iter(true).enumerate() {
+        for (i, row) in tables.nodes_iter().enumerate() {
             assert!(row.id == i as tsk_id_t);
-            assert!(row == tables.nodes().row(i as tsk_id_t, true).unwrap());
-            assert!(!(row != tables.nodes().row(i as tsk_id_t, true).unwrap()));
+            assert!(row == tables.nodes().row(i as tsk_id_t).unwrap());
+            assert!(!(row != tables.nodes().row(i as tsk_id_t).unwrap()));
         }
-        assert!(tables.nodes().row(0, true).unwrap() != tables.nodes().row(1, true).unwrap());
-        assert!(tables.nodes().row(1, true).unwrap() != tables.nodes().row(2, true).unwrap());
+        assert!(tables.nodes().row(0).unwrap() != tables.nodes().row(1).unwrap());
+        assert!(tables.nodes().row(1).unwrap() != tables.nodes().row(2).unwrap());
     }
 
     #[test]
@@ -1142,10 +1142,7 @@ mod test {
             None => panic!("expected some locations"),
         }
 
-        assert!(
-            tables.individuals().row(0, true).unwrap()
-                == tables.individuals().row(0, true).unwrap()
-        );
+        assert!(tables.individuals().row(0).unwrap() == tables.individuals().row(0).unwrap());
     }
 }
 

--- a/src/table_iterator.rs
+++ b/src/table_iterator.rs
@@ -3,16 +3,8 @@ use crate::tsk_id_t;
 pub struct TableIterator<T> {
     pub(crate) table: T,
     pub(crate) pos: tsk_id_t,
-    pub(crate) decode_metadata: bool,
 }
 
-pub(crate) fn make_table_iterator<TABLE>(
-    table: TABLE,
-    decode_metadata: bool,
-) -> TableIterator<TABLE> {
-    TableIterator {
-        table,
-        pos: 0,
-        decode_metadata,
-    }
+pub(crate) fn make_table_iterator<TABLE>(table: TABLE) -> TableIterator<TABLE> {
+    TableIterator { table, pos: 0 }
 }

--- a/src/test_simplification.rs
+++ b/src/test_simplification.rs
@@ -12,7 +12,7 @@ mod tests {
     fn test_simplify_tables() {
         let mut tables = make_small_table_collection_two_trees();
         let mut samples: Vec<tsk_id_t> = vec![];
-        for (i, row) in tables.nodes_iter(false).enumerate() {
+        for (i, row) in tables.nodes_iter().enumerate() {
             if row.flags & TSK_NODE_IS_SAMPLE > 0 {
                 samples.push(i as tsk_id_t);
             }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -62,8 +62,8 @@ pub trait TableAccess {
 
     /// Return an iterator over the edges.
     /// See [`EdgeTable::iter`] for details.
-    fn edges_iter(&self, decode_metadata: bool) -> EdgeTableIterator {
-        make_table_iterator::<EdgeTable>(self.edges(), decode_metadata)
+    fn edges_iter(&self) -> EdgeTableIterator {
+        make_table_iterator::<EdgeTable>(self.edges())
     }
 
     /// Get reference to the [``NodeTable``](crate::NodeTable).
@@ -71,8 +71,8 @@ pub trait TableAccess {
 
     /// Return an iterator over the nodes.
     /// See [`NodeTable::iter`] for details.
-    fn nodes_iter(&self, decode_metadata: bool) -> NodeTableIterator {
-        make_table_iterator::<NodeTable>(self.nodes(), decode_metadata)
+    fn nodes_iter(&self) -> NodeTableIterator {
+        make_table_iterator::<NodeTable>(self.nodes())
     }
 
     /// Get reference to the [``MutationTable``](crate::MutationTable).
@@ -80,8 +80,8 @@ pub trait TableAccess {
 
     /// Return an iterator over the mutations.
     /// See [`MutationTable::iter`] for details.
-    fn mutations_iter(&self, decode_metadata: bool) -> MutationTableIterator {
-        make_table_iterator::<MutationTable>(self.mutations(), decode_metadata)
+    fn mutations_iter(&self) -> MutationTableIterator {
+        make_table_iterator::<MutationTable>(self.mutations())
     }
 
     /// Get reference to the [``SiteTable``](crate::SiteTable).
@@ -89,8 +89,8 @@ pub trait TableAccess {
 
     /// Return an iterator over the sites.
     /// See [`SiteTable::iter`] for details.
-    fn sites_iter(&self, decode_metadata: bool) -> SiteTableIterator {
-        make_table_iterator::<SiteTable>(self.sites(), decode_metadata)
+    fn sites_iter(&self) -> SiteTableIterator {
+        make_table_iterator::<SiteTable>(self.sites())
     }
 
     /// Get reference to the [``PopulationTable``](crate::PopulationTable).
@@ -98,8 +98,8 @@ pub trait TableAccess {
 
     /// Return an iterator over the populations.
     /// See [`PopulationTable::iter`] for details.
-    fn populations_iter(&self, decode_metadata: bool) -> PopulationTableIterator {
-        make_table_iterator::<PopulationTable>(self.populations(), decode_metadata)
+    fn populations_iter(&self) -> PopulationTableIterator {
+        make_table_iterator::<PopulationTable>(self.populations())
     }
 
     /// Get reference to the [``MigrationTable``](crate::MigrationTable).
@@ -107,8 +107,8 @@ pub trait TableAccess {
 
     /// Return an iterator over the migration events.
     /// See [`MigrationTable::iter`] for details.
-    fn migrations_iter(&self, decode_metadata: bool) -> MigrationTableIterator {
-        make_table_iterator::<MigrationTable>(self.migrations(), decode_metadata)
+    fn migrations_iter(&self) -> MigrationTableIterator {
+        make_table_iterator::<MigrationTable>(self.migrations())
     }
 
     /// Get reference to the [``IndividualTable``](crate::IndividualTable).
@@ -116,8 +116,8 @@ pub trait TableAccess {
 
     /// Return an iterator over the individuals.
     /// See [`IndividualTable::iter`] for details.
-    fn individuals_iter(&self, decode_metadata: bool) -> IndividualTableIterator {
-        make_table_iterator::<IndividualTable>(self.individuals(), decode_metadata)
+    fn individuals_iter(&self) -> IndividualTableIterator {
+        make_table_iterator::<IndividualTable>(self.individuals())
     }
 }
 
@@ -177,7 +177,7 @@ pub trait NodeListGenerator: TableAccess {
     ///     tabled_type: &dyn tskit::TableAccess,
     ///     row: &tskit::NodeTableRow,
     /// ) -> bool {
-    ///     for mrow in tabled_type.mutations_iter(false) {
+    ///     for mrow in tabled_type.mutations_iter() {
     ///         if mrow.node == row.id {
     ///             return true;
     ///         }


### PR DESCRIPTION
This PR changes how row proxy objects are built.  In essence, a copy of the row metadata is always made.